### PR TITLE
Revert because of breaking current server OSes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -181,7 +181,7 @@ QString os_username;
                 SLOT(updateTimeLeft(int))
                 );
 
-    QObject::connect( networkClient, SIGNAL(messageRecieved(QString)), timerWindow, SLOT(showMessage(QString)));
+//    QObject::connect( networkClient, SIGNAL(messageRecieved(QString)), timerWindow, SLOT(showMessage(QString)));
 
     QObject::connect( networkClient, SIGNAL(allowClose(bool)), loginWindow, SLOT(setAllowClose(bool)));
     QObject::connect( networkClient, SIGNAL(allowClose(bool)), timerWindow, SLOT(setAllowClose(bool)));

--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -20,10 +20,6 @@
 #include "networkclient.h"
 
 #include <QtNetwork/QHostInfo>
-#include <QJsonDocument>
-#include <QJsonValue>
-#include <QJsonArray>
-#include <QJsonObject>
 
 NetworkClient::NetworkClient() : QObject() {
     qDebug("NetworkClient::NetworkClient");
@@ -204,25 +200,25 @@ void NetworkClient::processGetUserDataUpdateReply(QNetworkReply* reply) {
 
     qDebug() << "Server Result: " << result;
 
-    QJsonDocument jd = QJsonDocument::fromJson(result);
+    QScriptValue sc;
+    QScriptEngine engine;
+    QString json = "(" + QString(result) + ")";
 
-    if ( jd.isObject() ){
-        QJsonObject jo = jd.object();
+    if ( engine.canEvaluate(json) ){
+        sc = engine.evaluate( json );
 
-            QString status = jo["status"].toString();
-            qDebug() << "STATUS: " << status;
+        if ( ! engine.hasUncaughtException() ) {
 
-            if ( status == "Logged in" ) {
-                QJsonArray messages = jo["messages"].toArray();
-                qDebug() << "MESSAGE ARRAY SIZE: " << messages.size();
-                for ( int i = 0; i < messages.size(); i++ ) {
-                    QString m = messages[i].toString();
-                    qDebug() << "MESSAGE: " << m;
-                    emit messageRecieved( m );
-                }
+//            QString message = sc.property("message").toString();
+//            if ( !message.isEmpty() && !message.isNull() ) {
+//                this->clearMessage();
+//                emit messageRecieved( message );
+//            }
 
-                int units = jo["units"].toString().toInt();
-                qDebug() << "UNITS: " << units;
+            QString status = sc.property("status").toString();
+            if ( status == "Logged in" ||
+                 status.contains( "concurrent sessions", Qt::CaseInsensitive)) {
+                int units = sc.property("units").toInteger();
 
                 emit timeUpdatedFromServer( units );
 
@@ -235,7 +231,7 @@ void NetworkClient::processGetUserDataUpdateReply(QNetworkReply* reply) {
             } else if ( status == "Kicked" ) {
                 doLogoutTasks();
             }
-
+        }
     }
 
     reply->abort();

--- a/networkclient.h
+++ b/networkclient.h
@@ -56,7 +56,7 @@ signals:
     void timeUpdatedFromServer( int minutes );
     void logoutSucceeded();
     void logoutFailed();
-    void messageRecieved( QString message );
+//    void messageRecieved( QString message );
     void allowClose( bool );
     void setReservationStatus( QString reserved_for );
     void handleBanners();

--- a/timerwindow.cpp
+++ b/timerwindow.cpp
@@ -199,18 +199,18 @@ void TimerWindow::showSystemTrayIconTimeLeftMessage(){
     }
 }
 
-void TimerWindow::showMessage( QString message ){
-    qDebug() << "TimerWindow::showMessage(" << message << ")";
+//void TimerWindow::showMessage( QString message ){
+//    qDebug("TimerWindow::showMessage");
 
-    QMessageBox msgBox;
-    msgBox.setWindowIcon(libkiIcon);
-    msgBox.setIcon(QMessageBox::Information);
-    msgBox.setText(tr("You have a message"));
-    msgBox.setInformativeText( message );
+//    QMessageBox msgBox;
+//    msgBox.setWindowIcon(libkiIcon);
+//    msgBox.setIcon(QMessageBox::Information);
+//    msgBox.setText(tr("You Have Recieve A Message"));
+//    msgBox.setInformativeText( message );
 
-    this->restoreTimerWindow();
-    msgBox.exec();
-}
+//    this->restoreTimerWindow();
+//    msgBox.exec();
+//}
 
 void TimerWindow::getSettings() {}
 

--- a/timerwindow.cpp
+++ b/timerwindow.cpp
@@ -68,9 +68,6 @@ void TimerWindow::startTimer( const QString&, const QString&, int minutes, int h
     if ( ! settings.value("labels/waiting_holds").toString().isEmpty() ) {
         waiting_holds_message = settings.value("labels/waiting_holds").toString();
     }
-    if ( hold_items_count > 0 ) {
-        this->showMessage(waiting_holds_message);
-    }
 }
 
 void TimerWindow::stopTimer() {

--- a/timerwindow.h
+++ b/timerwindow.h
@@ -52,7 +52,7 @@ public slots:
     void startTimer( const QString& username, const QString& password, int minutes, int hold_items_count );
     void stopTimer();
     void updateTimeLeft( int minutes );
-    void showMessage( QString message );
+//    void showMessage( QString message );
 
 private slots:
     void doLogoutDialog();


### PR DESCRIPTION
See issue https://github.com/Libki/libki-client/issues/9 for a complete explanation. 

The short story is that this revert makes the client work with servers newer than Debian Jessie (i.e. Stretch and Ubuntu Server 16.04.3, which are the ones I've tested it on).