### PR TITLE
I noticed the labels from the ini didn't work...

### DIFF
--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -76,6 +76,7 @@ void LoginWindow::setupActions() {
 void LoginWindow::getSettings() {
   /* Set Labels */
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   if (!settings.value("labels/username").toString().isEmpty()) {
     usernameLabel->setText(settings.value("labels/username").toString());
@@ -133,6 +134,7 @@ void LoginWindow::attemptLogin() {
 
   if (username.isEmpty()) {
     QSettings settings;
+    settings.setIniCodec("UTF-8");
     QString   md5FromIni = settings.value("node/password").toString();
 
     if (!md5FromIni.isEmpty()) {
@@ -325,6 +327,7 @@ void LoginWindow::handleReservationStatus(QString reserved_for) {
 
 void LoginWindow::handleBanners() {
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   QPalette palette = bannerWebViewTop->palette();
 

--- a/main.cpp
+++ b/main.cpp
@@ -93,6 +93,7 @@ int main(int argc, char *argv[]) {
   QSettings::setDefaultFormat(QSettings::IniFormat);
 
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   QString onlyRunFor;
   onlyRunFor = settings.value("node/onlyRunFor").toString();

--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -41,6 +41,7 @@ NetworkClient::NetworkClient() : QObject() {
 #endif // ifdef Q_OS_UNIX
 
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   nodeName = settings.value("node/name").toString();
 
@@ -413,6 +414,7 @@ void NetworkClient::processRegisterNodeReply(QNetworkReply *reply) {
   }
 
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   QString bannerTopURL    = settings.value("session/BannerTopURL").toString();
   QString bannerBottomURL = settings.value("session/BannerBottomURL").toString();

--- a/timerwindow.cpp
+++ b/timerwindow.cpp
@@ -76,6 +76,7 @@ void TimerWindow::startTimer(const QString&,
   updateClock();
 
   QSettings settings;
+  settings.setIniCodec("UTF-8");
 
   QString waiting_holds_message =
     "You have one or more items on hold waiting for pickup. Please contact a librarian for more details";


### PR DESCRIPTION
...as supposed if they contained non-default letters (i.e. åäö). This tells everything that the settings are stored in UTF-8. I needed this on the spot, so I whipped it up.

I didn't really want to make the code extensively long, so I didn't add this at every instance. It would be great if it could be created as a function and reuse it, but since it's in several files I guess the best way would be to create a separate functions file and import that one. However, since I would like stuff to follow the same layout as the rest of the code, and I'm not really sure on how that layout's supposed to be, I thought it was better if I just leave it here. 

So if this is made into a function, just search and replace ```settings.setIniCodec("UTF-8");``` in the .cpp files and it would be a lot neater.

```
#ifdef Q_OS_WIN
    settings.setIniCodec("ANSI");
#else
    settings.setIniCodec("UTF-8");
#endif
```