### PR TITLE
Add instruction to kill explorer Windows during logout and launch dur…

### DIFF
--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -155,6 +155,7 @@ void LoginWindow::attemptLogin() {
 
         // If this is an MS Windows platform, use the keylocker programs to
         // limit mischief.
+        QProcess::startDetached("c:/windows/explorer.exe");
         QProcess::startDetached("windows/on_login.exe");
 #endif // ifdef Q_OS_WIN
         exit(1);

--- a/main.cpp
+++ b/main.cpp
@@ -123,6 +123,7 @@ int main(int argc, char *argv[]) {
 
   // If this is an MS Windows platform, use the keylocker programs to limit
   // mischief.
+  QProcess::startDetached("taskkill /f /im explorer.exe");
   QProcess::startDetached("windows/on_startup.exe");
 #endif // ifdef Q_OS_WIN
 

--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -509,6 +509,7 @@ void NetworkClient::doLoginTasks(int units, int hold_items_count) {
 
   // If this is an MS Windows platform, use the keylocker programs to limit
   // mischief.
+  QProcess::startDetached("c:/windows/explorer.exe");
   QProcess::startDetached("windows/on_login.exe");
 #endif // ifdef Q_OS_WIN
 
@@ -560,6 +561,7 @@ void NetworkClient::doLogoutTasks() {
 
   // If this is an MS Windows platform, use the keylocker programs to limit
   // mischief.
+  QProcess::startDetached("taskkill /f /im explorer.exe");
   QProcess::startDetached("windows/on_logout.exe");
 
   if (actionOnLogout == LogoutAction::Logout) {


### PR DESCRIPTION
Hi all,
this patch solves the problem of touch screens.
Without the patch: 
- When Libki locks the screen, you can easily open content on the computer without authenticating,   which breaks a serious problem.
- In some Windows Os (7), the start button remains visible after locking the screen.
Thanks.
Bouzid.
