### PR TITLE
Moved ToS text to Detailed Text field

### DIFF
--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -172,7 +172,8 @@ void LoginWindow::attemptLogin() {
   if ( termsOfService.length() > 4 ) {
       QMessageBox msgBox;
       msgBox.setText("Do you accept the terms of service?");
-      msgBox.setInformativeText(termsOfService);
+      msgBox.setInformativeText("You must accept the terms of service to use this kiosk.");
+      msgBox.setDetailedText(termsOfService);
       msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
       msgBox.setDefaultButton(QMessageBox::No);
       msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));


### PR DESCRIPTION
I had an usual problem where a really long ToS (as the one we're required to use) caused the box to overflow, and the yes and no buttons fell off the bottom of the screen, making them impossible to click. By moving them into the Detailed text field, we get that scrollbox instead, which prevents the buttons from falling off the bottom of the screen.