### PR TITLE
The client can receive a signal to remotely unlock it

### DIFF
--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -420,6 +420,12 @@ void NetworkClient::processRegisterNodeReply(QNetworkReply *reply) {
     qDebug("Node Registration FAILED");
   }
 
+  if (sc.property("unlock").toBoolean()) {
+    qDebug("Unlocking...");
+    username = sc.property("username").toString();
+    doLoginTasks(sc.property("minutes").toInteger(), 0);
+  }
+
   QSettings settings;
   settings.setIniCodec("UTF-8");
 


### PR DESCRIPTION
This feature must be tested with the corresponding patch for the server.

In the server, a new unlock button in the client table makes it possible for an admin user to remotely unlock a client. A session will be started on the client for a guest user named using the guest prefix and the client name. When the client receives the signal (during the register_node action), it will unlock.