### PR TITLE
Bug fix and build script for deb packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2020-06-03
+### Added
+- Bug fix. If banners wasn't being used, an error message was displayed about it not being able to find the host.
+
 ## [2.2.0] - 2020-05-29
 ### Added
 - Added the ability for users to temporarily lock an active session, in order to step away from the client. Feature is enabled via a setting on the Libki server. Requires Libki Server 4.2.4 or later.

--- a/deploy/linux/build_deb.sh
+++ b/deploy/linux/build_deb.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+version=$(grep FileVersion ../../libki.rc | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+
+arch=$(uname -m)
+
+if [[ $arch == "x86_64" ]]; then
+  arch="amd64"
+fi
+
+buildname="libkiclient_${version}_${arch}"
+
+mkdir build
+cd build
+
+qmake ../../../Libki.pro
+make
+
+cd ..
+
+mkdir -p deb/usr/bin
+mkdir -p deb/etc/xdg
+
+mv build/libkiclient deb/usr/bin/libkiclient
+
+cp ../../example.ini deb/etc/xdg/Libki.ini
+
+rm build -r
+
+cp deb/DEBIAN/control deb/DEBIAN/control.bak
+
+sed -i "s/VERSION/$version/g" deb/DEBIAN/control
+sed -i "s/ARCH/$arch/g" deb/DEBIAN/control
+
+dpkg -b deb $buildname.deb
+
+rm deb/usr/bin/libkiclient
+rm deb/etc/xdg/Libki.ini
+
+mv deb/DEBIAN/control.bak deb/DEBIAN/control

--- a/deploy/linux/deb/DEBIAN/conffiles
+++ b/deploy/linux/deb/DEBIAN/conffiles
@@ -1,0 +1,1 @@
+/etc/xdg/Libki.ini

--- a/deploy/linux/deb/DEBIAN/control
+++ b/deploy/linux/deb/DEBIAN/control
@@ -1,0 +1,7 @@
+Package: libkiclient
+Version: VERSION
+Maintainer: Kyle M Hall
+Description: The client for Libki kiosk management system.
+Homepage: https://libki.org
+Architecture: ARCH
+Depends: libqt5webkit5, libqt5script5

--- a/libki.rc
+++ b/libki.rc
@@ -3,8 +3,8 @@ IDI_ICON1               ICON    DISCARDABLE     "images/icons/libki.ico"
 #include <windows.h>
 
 VS_VERSION_INFO     VERSIONINFO
-FILEVERSION         2, 2, 0, 0
-PRODUCTVERSION      2, 2, 0, 0
+FILEVERSION         2, 2, 1, 0
+PRODUCTVERSION      2, 2, 1, 0
 FILEFLAGSMASK       0x3fL
 FILEFLAGS           0
 FILEOS              VOS_NT_WINDOWS32
@@ -21,9 +21,9 @@ BEGIN
         BLOCK   "040904b0"
         BEGIN
             VALUE   "ProductName",      		"Libki Kiosk Management System\0"
-            VALUE   "ProductVersion",   		"Client v2.2.0 Api v1.0\0"
+            VALUE   "ProductVersion",   		"Client v2.2.1 Api v1.0\0"
 			VALUE   "FileDescription",  		"Libki Client\0"
-			VALUE   "FileVersion",      		"2.2.0\0"
+			VALUE   "FileVersion",      		"2.2.1\0"
             VALUE   "InternalName",     		"Libki\0"
             VALUE   "LegalCopyright",   		"Copyright 2014 Kyle M Hall\0"
         END

--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -396,7 +396,7 @@ void LoginWindow::handleBanners() {
   QString bannerTopUrl = "http://" +
                          settings.value("session/BannerTopURL").toString();
 
-  if (!bannerTopUrl.isEmpty()) {
+  if (bannerTopUrl!="http://") {
     int bannerTopHeight = settings.value("session/BannerTopHeight").toInt();
     int bannerTopWidth  = settings.value("session/BannerTopWidth").toInt();
 
@@ -413,7 +413,7 @@ void LoginWindow::handleBanners() {
   QString bannerBottomUrl = "http://" +
                             settings.value("session/BannerBottomURL").toString();
 
-  if (!bannerBottomUrl.isEmpty()) {
+  if (bannerBottomUrl!="http://") {
     int bannerBottomHeight = settings.value("session/BannerBottomHeight").toInt();
     int bannerBottomWidth  = settings.value("session/BannerBottomWidth").toInt();
 


### PR DESCRIPTION
The bug fix is in `loginwindow.cpp` which caused a error message if no banners was in use. The build script pushes out a deb package for the architecture its run on and gets version number from `libki.rc`.

@kylemhall Are there version numbers anywhere else than in `libki.rc` that should be updated?