### PR TITLE
Makes the terms of service accept html

### DIFF
--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -19,6 +19,7 @@
 
 #include <QCryptographicHash>
 #include <QMessageBox>
+#include <QTextEdit>
 
 #include "loginwindow.h"
 #include "utils.h"
@@ -174,6 +175,10 @@ void LoginWindow::attemptLogin() {
       msgBox.setText("Do you accept the terms of service?");
       msgBox.setInformativeText(tr("Terms of Service"));
       msgBox.setDetailedText(termsOfService);
+      if (Qt::mightBeRichText(termsOfService)) {
+        QTextEdit *detailedText = msgBox.findChild<QTextEdit *>();
+        detailedText->setHtml(termsOfService);
+      }
       msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
       msgBox.setDefaultButton(QMessageBox::No);
       msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));


### PR DESCRIPTION
Before pull request #56, terms of service could use html tags for formatting. With ToS moved to detailedText, it is now always shown as plain text. This commit reintroduces formatting when the string looks like it might be rich text.