### PR TITLE
Add the possibility to send Wake on LAN packets from the client

### DIFF
--- a/networkclient.h
+++ b/networkclient.h
@@ -116,6 +116,8 @@ private:
   void doLoginTasks(int units,
                     int hold_items_count);
   void doLogoutTasks();
+
+  void wakeOnLan(QStringList MAC_addresses, QString host, qint64 port);
 };
 
 #endif // NETWORKCLIENT_H


### PR DESCRIPTION
Adds wake on LAN capabilities to the client. If the corresponding signal is received during registering to the server, magic packets are sent using mac addresses, host and port information from the server.