### PR TITLE
Enable/Disable login according to status received from the server

### DIFF
--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -433,3 +433,16 @@ void LoginWindow::handleBanners() {
     bannerWebViewBottom->load(QUrl(bannerBottomUrl));
   }
 }
+
+void LoginWindow::disableLogin() {
+  qDebug("LoginWindow::disableLogin");
+  this->setButtonsEnabled(false);
+  messageLabel->setVisible(false);
+  errorLabel->setText(tr("This kiosk is out of order."));
+}
+
+void LoginWindow::enableLogin() {
+  qDebug("LoginWindow::enableLogin");
+  this->resetLoginScreen();
+  messageLabel->setVisible(true);
+}

--- a/loginwindow.h
+++ b/loginwindow.h
@@ -61,6 +61,8 @@ public slots:
                            int     hold_items_count);
   void handleReservationStatus(QString reserved_for);
   void handleBanners();
+  void disableLogin();
+  void enableLogin();
 
 private slots:
 

--- a/main.cpp
+++ b/main.cpp
@@ -212,6 +212,20 @@ int main(int argc, char *argv[]) {
 
   QObject::connect(
     networkClient,
+    SIGNAL(clientSuspended()),
+    loginWindow,
+    SLOT(disableLogin())
+    );
+
+  QObject::connect(
+    networkClient,
+    SIGNAL(clientOnline()),
+    loginWindow,
+    SLOT(enableLogin())
+    );
+
+  QObject::connect(
+    networkClient,
     SIGNAL(timeUpdatedFromServer(int)),
     timerWindow,
     SLOT(updateTimeLeft(int))

--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -78,6 +78,8 @@ NetworkClient::NetworkClient() : QObject() {
     actionOnLogout = LogoutAction::NoAction;
   }
 
+  clientStatus = "online";
+
   qDebug() << "HOST: " << settings.value("server/host").toString();
   serviceURL.setHost(settings.value("server/host").toString());
   serviceURL.setPort(settings.value("server/port").toInt());
@@ -517,6 +519,16 @@ void NetworkClient::processRegisterNodeReply(QNetworkReply *reply) {
 
   QString reserved_for = sc.property("reserved_for").toString();
   emit    setReservationStatus(reserved_for);
+
+  QString status = sc.property("status").toString();
+  if (status != clientStatus) {
+    if (status == "suspended") {
+      emit clientSuspended();
+    } else if (status == "online") {
+      emit clientOnline();
+    }
+  }
+  clientStatus = status;
 
   reply->abort();
   reply->deleteLater();

--- a/networkclient.h
+++ b/networkclient.h
@@ -65,6 +65,8 @@ signals:
   void allowClose(bool);
   void setReservationStatus(QString reserved_for);
   void handleBanners();
+  void clientSuspended();
+  void clientOnline();
 
 public slots:
 
@@ -107,6 +109,8 @@ private:
   QString nodeAgeLimit;
 
   LogoutAction::Enum actionOnLogout;
+
+  QString clientStatus;
 
   QString username;
   QString password;


### PR DESCRIPTION
When a client's status is set to "suspended", disables login and states the client as "out of order". If the status is set back to "online" from something else, re-enables the login.

To test, the server needs to transmit the status during node registering.
1) If client's status is set as online (or anything except "suspended"), client's behavior should remain the same.
2) Toggle client's status on the server to set it to "suspended". Login should be disabled: textboxes and buttons are grayed out and an "out of order" message is show.
3) Toggle client's status on the server to set it to back to "online". Login should return to normal when the client registers next with the server.