### PR TITLE
Add client name to login screen #88

### DIFF
--- a/Libki.pro
+++ b/Libki.pro
@@ -15,7 +15,8 @@ QT += webkitwidgets
 HEADERS += loginwindow.h networkclient.h timerwindow.h \
     sessionlockedwindow.h \
     logutils.h \
-    timesplash.h
+    timesplash.h \
+    utils.h
 FORMS += loginwindow.ui timerwindow.ui \
     sessionlockedwindow.ui
 RESOURCES += libki.qrc

--- a/loginwindow.cpp
+++ b/loginwindow.cpp
@@ -57,6 +57,8 @@ LoginWindow::LoginWindow(QWidget *parent) : QMainWindow(parent) {
   serverAccessWarning->hide();
   internetAccessWarning->hide();
 
+  clientNameLabel->setText(getClientName());
+
   handleBanners();
 
   showMe();

--- a/loginwindow.ui
+++ b/loginwindow.ui
@@ -504,6 +504,9 @@
       <property name="layoutDirection">
        <enum>Qt::RightToLeft</enum>
       </property>
+      <property name="styleSheet">
+       <string notr="true">padding-right: 25px</string>
+      </property>
       <property name="text">
        <string>2.2.16</string>
       </property>
@@ -585,6 +588,19 @@ color: red;</string>
        </widget>
       </item>
      </layout>
+    </item>
+    <item row="1" column="2">
+     <widget class="QLabel" name="clientNameLabel">
+      <property name="styleSheet">
+       <string notr="true">padding-right: 25px</string>
+      </property>
+      <property name="text">
+       <string notr="true"/>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>

--- a/networkclient.cpp
+++ b/networkclient.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "networkclient.h"
+#include "utils.h"
 
 #include <QDir>
 #include <QHttpMultiPart>
@@ -28,7 +29,6 @@
 #include <QList>
 #include <QSslError>
 #include <QUdpSocket>
-#include <QtNetwork/QHostInfo>
 
 NetworkClient::NetworkClient(QApplication *app) : QObject() {
   qDebug("ENTER NetworkClient::NetworkClient");
@@ -41,33 +41,10 @@ NetworkClient::NetworkClient(QApplication *app) : QObject() {
 
   fileCounter = 0;
 
-  QString os_username;
-#ifdef Q_OS_WIN
-  os_username = getenv("USERNAME");
-#endif  // ifdef Q_OS_WIN
-#ifdef Q_OS_UNIX
-  os_username = getenv("USER");
-#endif  // ifdef Q_OS_UNIX
-
   QSettings settings;
   settings.setIniCodec("UTF-8");
 
-  nodeName = settings.value("node/name").toString();
-
-  qDebug() << "OS USERNAME: " << os_username;
-  qDebug() << "CONFIG NODE NAME: " << nodeName;
-
-  if (nodeName == "OS_USERNAME") {
-    nodeName = os_username;
-  }
-
-  // Fail over to hostname if node name isn't defined.
-  if (nodeName.isEmpty()) {
-    QHostInfo hostInfo;
-    hostInfo = QHostInfo::fromName(QHostInfo::localHostName());
-    nodeName = QHostInfo::localHostName();
-  }
-  qDebug() << "NODE NAME: " << nodeName;
+  nodeName = getClientName();
 
   nodeLocation = settings.value("node/location").toString();
   qDebug() << "LOCATION: " << nodeLocation;

--- a/utils.cpp
+++ b/utils.cpp
@@ -19,9 +19,10 @@
 
 #include "utils.h"
 
-#include <QLocale>
-#include <QSettings>
 #include <QDebug>
+#include <QLocale>
+#include <QtNetwork/QHostInfo>
+#include <QSettings>
 
 QString getLabel(QString labelcode) {
   qDebug("ENTER utils/getLabel");
@@ -51,4 +52,43 @@ QString getLabel(QString labelcode) {
 
   qDebug("LEAVE utils/getLabel");
   return label;
+}
+
+QString clientName = "";
+QString getClientName() {
+    qDebug("ENTER utils/getClientName");
+
+    if ( clientName.length() == 0 ) {
+        QSettings settings;
+        settings.setIniCodec("UTF-8");
+
+
+        QString os_username;
+#ifdef Q_OS_WIN
+        os_username = getenv("USERNAME");
+#endif  // ifdef Q_OS_WIN
+#ifdef Q_OS_UNIX
+        os_username = getenv("USER");
+#endif  // ifdef Q_OS_UNIX
+
+        clientName = settings.value("node/name").toString();
+
+        qDebug() << "OS USERNAME: " << os_username;
+        qDebug() << "CONFIG NODE NAME: " << clientName;
+
+        if (clientName == "OS_USERNAME") {
+          clientName = os_username;
+        }
+
+        // Fail over to hostname if node name isn't defined.
+        if (clientName.isEmpty()) {
+          QHostInfo hostInfo;
+          hostInfo = QHostInfo::fromName(QHostInfo::localHostName());
+          clientName = QHostInfo::localHostName();
+        }
+        qDebug() << "NODE NAME: " << clientName;
+    }
+
+    qDebug("LEAVE utils/getClientName");
+    return clientName;
 }

--- a/utils.h
+++ b/utils.h
@@ -24,4 +24,6 @@
 
 QString getLabel(QString labelcode);
 
+QString getClientName();
+
 #endif  // UTILS_H


### PR DESCRIPTION
It would be good and useful to add the client name that Libki chooses for a given client to the login screen. This will: A) Allow users to know which machine is which ( great for reservations ) B) Allow administrators to know if the client name is set up correctly