### PR TITLE
Add the client name to the locked session screen #92

### DIFF
--- a/sessionlockedwindow.cpp
+++ b/sessionlockedwindow.cpp
@@ -38,6 +38,8 @@ SessionLockedWindow::SessionLockedWindow(QWidget *parent, QString userUsername,
 
   getSettings();
 
+  clientNameLabel->setText(getClientName());
+
   // handleBanners(); // Do we really want banners on the lock screen?
 
   this->show();

--- a/sessionlockedwindow.ui
+++ b/sessionlockedwindow.ui
@@ -400,6 +400,13 @@
       </item>
      </layout>
     </item>
+    <item row="1" column="2">
+     <widget class="QLabel" name="clientNameLabel">
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">


### PR DESCRIPTION
This enhancement adds the client name to the locked session screen as it is on the login screen.