### PR TITLE
Add support for keyboard input when checking for inactivity on Windows

### DIFF
--- a/timerwindow.h
+++ b/timerwindow.h
@@ -83,6 +83,13 @@ class TimerWindow : public QMainWindow, public Ui::TimerWindow {
   int minutesRemaining;
   int minutesAtStart;
 
+  #ifdef Q_OS_WIN
+    DWORD lastInputTick;
+    DWORD systemTickRangeStart;
+    DWORD systemTickRangeEnd;
+  #endif
+
+  bool userIdle;
   int secondsSinceLastActivity;
   int prevMousePosX;
   int prevMousePosY;


### PR DESCRIPTION
When compiled for Windows, use the Windows API (specifically GetLastInputInfo) to check for inactivity. 

GetLastInputInfo retrieves the tick count (milliseconds since Windows was started) of the last input event. If the input event occurred between the last and current inactivity check, the user is considered active. 

More info on GetLastInputInfo: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getlastinputinfo
